### PR TITLE
overlays/nixos-icons: update system attr warning

### DIFF
--- a/overlays/nixos-icons/default.nix
+++ b/overlays/nixos-icons/default.nix
@@ -1,4 +1,4 @@
 { self, ... }:
 finalPkgs: prevPkgs: {
-  nixos-icons = self.legacyPackages.${finalPkgs.system}.nixowos-icons;
+  nixos-icons = self.legacyPackages.${finalPkgs.stdenv.hostPlatform.system}.nixowos-icons;
 }


### PR DESCRIPTION
fixes this warning:
`evaluation warning: 'system' has been renamed to/replaced by 'stdenv.hostPlatform.system'`